### PR TITLE
Serve external script over secure connection

### DIFF
--- a/eqd_idb_comment_archive.html
+++ b/eqd_idb_comment_archive.html
@@ -28,7 +28,7 @@ var idcomments_post_title = getParameterByName("post_title");
 </head>
 <body>
 <h5>This page is for archival purposes only. Comments made on this page will not be processed</h5>
-<script type="text/javascript" src="http://www.intensedebate.com/js/genericCommentWrapperV2.js"></script>
+<script type="text/javascript" src="https://www.intensedebate.com/js/genericCommentWrapperV2.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
People accessing the comment archive over a secure connection (HTTPS) may run into mixed content errors preventing the comments from loading since you are using an external script from a non-secure connection.

To reproduce this issue, open https://equestriadaily.github.io/eqd_idb_comment_archive.html?post_id=5873834470144116240&post_link=http://www.equestriadaily.com/2015/12/luna-day-plushies-crafts-and-customs.html&post_title=Luna%20Day:%20Plushies,%20Crafts,%20and%20Customs! in the latest version of chrome.

Serving the script over a secure connection should allow the comments to load for people using a secure connection :+1: 
